### PR TITLE
Changing when "today" is

### DIFF
--- a/src/seiir_model/ode_model/ode_process.py
+++ b/src/seiir_model/ode_model/ode_process.py
@@ -382,7 +382,7 @@ class ODEProcess:
             self.col_lag_days].values[0]
         self.today_dict = {
             loc_id: np.datetime64(
-                self.df_dict[loc_id][self.df_dict[loc_id][self.col_observed] == 1, self.col_date].max()
+                self.df_dict[loc_id].loc[self.df_dict[loc_id][self.col_observed] == 1, self.col_date].max()
             )
             for loc_id in self.loc_ids
         }


### PR DESCRIPTION
Gives us the option to use a different today based on the version of the data. Will be used in conjunction with a PR to the stash repository to pass in date of last observed deaths as "today".