### PR TITLE
Add 'sequential' as an option to be passed to fit_beta_regression_prod()

### DIFF
--- a/src/covid_model_seiir/model_runner.py
+++ b/src/covid_model_seiir/model_runner.py
@@ -57,11 +57,6 @@ class ModelRunner:
         # save other parameters
         self.get_beta_ode_params().to_csv(params_file, index=False)
 
-    def fit_beta_regression(self, ordered_covmodel_sets, mr_data, path, add_intercept=True, std=1.0):
-        regressor = BetaRegressorSequential(ordered_covmodel_sets, default_std=std)
-        regressor.fit(mr_data, verbose=True, add_intercept=add_intercept)
-        regressor.save_coef(path)
-
     def predict_beta_forward(self, covmodel_set, df_cov, df_cov_coef, col_t, col_group, col_beta='ln_beta_pred'):
         regressor = BetaRegressor(covmodel_set)
         regressor.load_coef(df=df_cov_coef)
@@ -76,23 +71,27 @@ class ModelRunner:
         cov_intercept = CovModel(col_cov='intercept', use_re=True, re_var=np.inf)
         return cov_temp, cov_testing, cov_pop_density, cov_mobility, cov_intercept
 
-    def fit_beta_regression_prod(self, ordered_covmodel_sets, mr_data, path, df_cov_coef=None, std=1.0, add_intercept=True):
-        covmodels = []
-        if add_intercept:
-            covmodels.append(CovModel(col_cov='intercept', use_re=True, re_var=np.inf))
-
-        for covmodel_set in ordered_covmodel_sets:
-            covmodels.extend(covmodel_set.cov_models)
-        covmodels_set_comb = CovModelSet(covmodels)
-        regressor = BetaRegressor(covmodels_set_comb)
-
+    def fit_beta_regression_prod(self, ordered_covmodel_sets, mr_data, path, 
+                                 df_cov_coef=None, std=1.0, sequential=False):
+        # If priors on coefficients are assigned from a data frame, add them
         if df_cov_coef is not None:
-            coef_values = df_cov_coef[[covmodel.col_cov for covmodel in covmodels]].to_numpy()
-
-            for i, covmodel in enumerate(covmodels_set_comb.cov_models):
-                if not covmodel.use_re:
-                    covmodel.gprior[0] = np.mean(coef_values[:, i])
-
+            coef_values = {col_name: df_cov_coef[col_name].to_numpy().mean() for col_name in df_cov_coef.columns}
+            for covmodelset in ordered_covmodel_sets:
+                for covmodel in covmodelset.cov_models:
+                    if (covmodel.col_cov in coef_values) and not covmodel.use_re:
+                        if covmodel.gprior is not None:
+                            covmodel.gprior[0] = coef_values[covmodel.col_cov]
+                        else:
+                            covmodel.gprior = np.array([coef_values[covmodel.col_cov], std])
+        # The regressor type depends on whether the regression is sequential
+        if sequential:
+            regressor = BetaRegressorSequential(ordered_covmodel_sets, default_std=std)
+        else:
+            covmodels = []
+            for covmodel_set in ordered_covmodel_sets:
+                covmodels.extend(covmodel_set.cov_models)
+            covmodels_set_comb = CovModelSet(covmodels)
+            regressor = BetaRegressor(covmodels_set_comb)
         regressor.fit(mr_data)
         print(regressor.cov_coef)
         regressor.save_coef(path)


### PR DESCRIPTION
This pull request adds `sequential` as an argument to `ModelRunner.fit_beta_regression_prod()`. It implements the beta regression specified in the "ihmeuw/covid-model-seiir/sequential" branch if `sequential` is `True`, and implements the standard (non-sequential) regression otherwise. This pull request corresponds to PR #18 in ihmeuw/covid-model-seiir-pipeline.